### PR TITLE
Enable Dependabot version updates for Gradle, pip, and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,48 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
+
 # Please see the documentation for all configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "gradle"
+    directories:
+      - "**/*"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Ignore Kotlin-related upgrades
+      - dependency-name: "org.jetbrains.kotlin*"
+    commit-message:
+      prefix: "build: Dependabot - [Gradle] -"
+
+  - package-ecosystem: "pip"
+    directories:
+      - "**/*"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "build: Dependabot - [Pip] -"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "build: Dependabot - [Actions] -"


### PR DESCRIPTION
## Summary
- Replaces the placeholder `dependabot.yml` (which had an empty `package-ecosystem` and was effectively disabled) with a working configuration
- Scans three ecosystems: Gradle, pip, and GitHub Actions
- Runs weekly; minor and patch updates are grouped into a single PR per ecosystem, while major updates get individual PRs
## Ecosystems
| Ecosystem | Scope |
|---|---|
| Gradle | All `build.gradle.kts` files (`**/*`) |
| Pip | Python `requirements.txt` files in `examples/python/` |
| GitHub Actions | Workflow action versions in `.github/workflows/` |
## Notes
- Kotlin-related dependencies (`org.jetbrains.kotlin*`) are excluded from Gradle updates
- The first run may produce a burst of PRs for any accumulated outdated dependencies