### PR TITLE
build: Add Dependabot auto-merge, expand CodeQL to Python/JS, and tighten dependency review

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,6 +46,10 @@ jobs:
         include:
         - language: java-kotlin
           build-mode: autobuild # This mode only analyzes Java. Set this to 'autobuild' or 'manual' to analyze Kotlin too.
+        - language: python
+          build-mode: none
+        - language: javascript-typescript
+          build-mode: none
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for minor and patch updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,26 +24,14 @@ permissions:
   pull-requests: write
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout sources
-      uses: actions/checkout@v4
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
-    - name: Build with Gradle
-      run: ./gradlew build
   dependency-review:
-    needs : build
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout repository'
         uses: actions/checkout@v4
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4
-        # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
         with:
           comment-summary-in-pr: always
-        #   fail-on-severity: moderate
-        #   deny-licenses: GPL-1.0-or-later, LGPL-2.0-or-later
+          fail-on-severity: moderate
           retry-on-snapshot-warnings: true


### PR DESCRIPTION
## Summary
- Adds a Dependabot auto-merge workflow for minor and patch updates
- Expands CodeQL scanning to include Python and JavaScript/TypeScript (in addition to existing Java/Kotlin)
- Simplifies the dependency review workflow by removing the unnecessary Gradle build prerequisite and enabling `fail-on-severity: moderate`
## Changes
### `dependabot-auto-merge.yml` (new)
Automatically squash-merges Dependabot PRs for minor and patch version bumps after CI passes. Major updates still require manual review.
### `codeql.yml`
Adds `python` and `javascript-typescript` to the CodeQL analysis matrix (both using `build-mode: none`), covering the Python examples and any JS/Node code in the repo.
### `dependency-review.yml`
- Removes the `build` job that was a prerequisite — dependency review doesn't need a full Gradle build
- Enables `fail-on-severity: moderate` so PRs introducing moderate+ vulnerabilities will be flagged
- Cleans up commented-out config